### PR TITLE
s/npm install/npm ci/

### DIFF
--- a/web/Makefile
+++ b/web/Makefile
@@ -69,7 +69,7 @@ clean-package:
 	rm -f *.tgz
 
 $(NODE_MODULES): package.json package-lock.json
-	npm install
+	npm ci
 	touch $(NODE_MODULES)
 
 $(LIBS_OUTPUT): public/dist/vendor/%.js : $(NODE_MODULES)


### PR DESCRIPTION
`npm install` installs dependencies according to `package.json` and updates `package-lock.json`.

`npm ci` installs dependencies according to `package-lock.json`.

It's better to use `npm ci` in the makefile, this way everyone has an exact copy of the dependencies, and we don't end up with huge `package-lock.json` diffs in every single pull request.